### PR TITLE
PRC-996: updateShapes.js now runs in batches and refreshes token before expiry.

### DIFF
--- a/api/helpers/auth.js
+++ b/api/helpers/auth.js
@@ -7,7 +7,7 @@ var ISSUER          = process.env.SSO_ISSUER || "https://sso-dev.pathfinder.gov.
 var JWKSURI         = process.env.SSO_JWKSURI || "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/prc/protocol/openid-connect/certs";
 var JWT_SIGN_EXPIRY = process.env.JWT_SIGN_EXPIRY || "1440"; // 24 hours in minutes.
 var SECRET          = process.env.SECRET || "defaultSecret";
-var KEYCLOAK_ENABLED = process.env.KEYCLOAK_ENABLED || "false";
+var KEYCLOAK_ENABLED = process.env.KEYCLOAK_ENABLED || "true";
 var winston         = require('winston');
 var defaultLog      = winston.loggers.get('default');
 
@@ -32,7 +32,7 @@ exports.verifyToken = function(req, authOrSecDef, token, callback) {
         strictSsl: true, // Default value
         jwksUri: JWKSURI
       });
-      
+
       const kid = jwt.decode(tokenString, { complete: true }).header.kid;
 
       client.getSigningKey(kid, (err, key) => {


### PR DESCRIPTION
Updated shapes script to run in batches (currently 100 at a time), and check if the token is near expiration at the start of each batch.

I also included a tiny change  in auth.js to enable keycloak by default now, as its really the only thing we support.